### PR TITLE
Arreglo de test unitario de ticket que utilizaba mock

### DIFF
--- a/app/test/test_unit/test_ticket.py
+++ b/app/test/test_unit/test_ticket.py
@@ -6,9 +6,10 @@ from app.models import *
 from app.views import *
 from datetime import datetime
 from django.core.exceptions import ValidationError
-class TicketUsuarioLimiteTest(unittest.TestCase):
 
-    @patch('app.models.Ticket.objects.filter')  # mockeamos el queryset filter
+
+class TicketUsuarioLimiteTest(unittest.TestCase):
+    @patch("app.models.Ticket.objects.filter")  # mockeamos el queryset filter
     def test_usuario_hasta_4_tickets(self, mock_filter):
         ticket1 = MagicMock(quantity=2, id=1)
         ticket2 = MagicMock(quantity=2, id=2)
@@ -17,30 +18,36 @@ class TicketUsuarioLimiteTest(unittest.TestCase):
         resultado = Ticket.ticket_excede_limite_usuario(user_id=1, event_id=1, nueva_cantidad=0)
         self.assertFalse(resultado)
 
-    @patch('app.models.Ticket.objects.filter')
+    @patch("app.models.Ticket.objects.filter")
     def test_limite_4_tickets(self, mock_filter):
         ticket1 = MagicMock(id=1, quantity=3)
         ticket2 = MagicMock(id=2, quantity=1)
         mock_filter.return_value = [ticket1, ticket2]
 
         # Sumar nueva cantidad 2 al ticket 1
-        resultado = Ticket.ticket_excede_limite_usuario(user_id=1, event_id=1, nueva_cantidad=2, ticket_id=1)
+        resultado = Ticket.ticket_excede_limite_usuario(
+            user_id=1, event_id=1, nueva_cantidad=2, ticket_id=1
+        )
         self.assertFalse(resultado, "No debe exceder el límite con 2 + 1 = 3")
-        
+
         # Sumar nueva cantidad 4 al ticket 1, excede
-        resultado = Ticket.ticket_excede_limite_usuario(user_id=1, event_id=1, nueva_cantidad=4, ticket_id=1)
+        resultado = Ticket.ticket_excede_limite_usuario(
+            user_id=1, event_id=1, nueva_cantidad=4, ticket_id=1
+        )
         self.assertTrue(resultado)
 
-    @patch('app.models.Ticket.objects.filter')
+    @patch("app.models.Ticket.objects.filter")
     def test_editar_superando_limite(self, mock_filter):
         ticket1 = MagicMock(quantity=2, id=1)
         ticket2 = MagicMock(quantity=2, id=2)
         mock_filter.return_value = [ticket1, ticket2]
 
-        resultado = Ticket.ticket_excede_limite_usuario(user_id=1, event_id=1, nueva_cantidad=3, ticket_id=1)
+        resultado = Ticket.ticket_excede_limite_usuario(
+            user_id=1, event_id=1, nueva_cantidad=3, ticket_id=1
+        )
         self.assertTrue(resultado)
 
-    @patch('app.models.Ticket.objects.filter')
+    @patch("app.models.Ticket.objects.filter")
     def test_editar_dentro_del_limite(self, mock_filter):
         ticket1 = MagicMock(id=1, quantity=2)
         ticket2 = MagicMock(id=2, quantity=1)
@@ -53,7 +60,7 @@ class TicketUsuarioLimiteTest(unittest.TestCase):
                 user_id=t1.user.id,
                 event_id=t1.event.id,
                 nueva_cantidad=t1.quantity,
-                ticket_id=t1.id
+                ticket_id=t1.id,
             ):
                 raise ValidationError("No puedes tener más de 4 tickets para un mismo evento.")
 
@@ -68,22 +75,26 @@ class TicketUsuarioLimiteTest(unittest.TestCase):
 # Verificar que al comprar un ticket con X lugares, no se sobrepase la capacidad de lugares del evento.
 class TicketCapacidadTest(TestCase):
     def setUp(self):
-        self.user = User.objects.create(username='test_user')
-        self.venue = Venue.objects.create(name='Teatro', capacity=100)
+        self.user = User.objects.create(username="test_user")
+        self.venue = Venue.objects.create(name="Teatro", capacity=100)
         self.event = Event.objects.create(
-            title='Obra',
-            description='Una obra de teatro',
+            title="Obra",
+            description="Una obra de teatro",
             scheduled_at=datetime.now(),  # campo obligatorio
             organizer=self.user,
-            venue=self.venue
+            venue=self.venue,
         )
 
     # Si el espacio tiene 90/100 lugares ocupados pero compro 10, el ticket NO excede la capacidad maxima
     def test_no_excede_capacidad(self):
-        Ticket.objects.create(user=self.user, event=self.event, quantity=90, buy_date=datetime.now())
+        Ticket.objects.create(
+            user=self.user, event=self.event, quantity=90, buy_date=datetime.now()
+        )
         self.assertFalse(ticket_excede_capacidad_maxima(self.event, 10))
 
     # Si el espacio tiene 100/100 lugares ocupados y compro 10, el ticket SI excede la capacidad maxima
     def test_excede_capacidad(self):
-        Ticket.objects.create(user=self.user, event=self.event, quantity=100, buy_date=datetime.now())
+        Ticket.objects.create(
+            user=self.user, event=self.event, quantity=100, buy_date=datetime.now()
+        )
         self.assertTrue(ticket_excede_capacidad_maxima(self.event, 1))

--- a/app/views.py
+++ b/app/views.py
@@ -258,10 +258,16 @@ def ticket_edit_form(request,ticket_code):
     return render(request, "app/ticket_edit_form.html",{"ticket":ticket})
 
 
-def ticket_excede_capacidad_maxima(event, quantity):
+def ticket_excede_capacidad_maxima(event, quantity) -> bool:
+    '''
+    Verifica que al comprar un ticket, no se superen los cupos maximos del espacio del evento.
+    Toma como parametros:
+    - Evento
+    - Cantidad de entradas a comprar en el ticket
+    '''
     capacidad_maxima = event.venue.capacity
     capacidad_utilizada = Ticket.objects.filter(event=event, bl_baja=0).aggregate(total=Sum("quantity"))["total"] or 0
-    print(f"capacidad utilizada: {capacidad_utilizada}")
+    # print(f"capacidad utilizada: {capacidad_utilizada}")
     if(capacidad_utilizada+quantity>capacidad_maxima):
         return True
     else:


### PR DESCRIPTION
Corrección del test unitario para validación de capacidad máxima al comprar tickets.
Este test asegura que no se exceda el límite de espacio disponible al intentar realizar una compra.
La necesidad de esta corrección surge a partir de la discusión detallada en el siguiente enlace:
🔗 [Discusión de donde proviene la corrección](https://github.com/orgs/frlp-utn-ingsoft/discussions/322)