### PR TITLE
[Actividad extra] Evitar que un usuario puede solicitar un reembolso si ya tiene una solicitud activa

### DIFF
--- a/app/templates/request_form.html
+++ b/app/templates/request_form.html
@@ -1,29 +1,36 @@
 {% extends "base.html" %}
 
 {% block content %}
+
+{% if messages %}
+<script>
+    {% for message in messages %}
+    alert("{{ message|escapejs }}");
+    {% endfor %}
+</script>
+{% endif %}
 <div class="container mt-5">
     <div class="row">
         <div class="col-md-8 offset-md-2">
-            <h1 class="mb-4">            
-                    Solicitar reembolso
+            <h1 class="mb-4">
+                Solicitar reembolso
             </h1>
             <div class="card">
                 <div class="card-body">
                     <form action="{% url 'solicitar_reembolso' %}" method="POST">
                         {% csrf_token %}
                         <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
-                            <i class="bi bi-exclamation-triangle-fill" style="font-size: 1.5em; color: #0d6efd; margin-right: 10px;"></i>
+                            <i class="bi bi-exclamation-triangle-fill"
+                                style="font-size: 1.5em; color: #0d6efd; margin-right: 10px;"></i>
                             <span style="color: #0d6efd;">
-                                Puedes solicitar un reembolso hasta 48 horas antes del evento. Una vez procesada la solicitud, el reembolso se realizará en un plazo de 7 a 14 días hábiles.
+                                Puedes solicitar un reembolso hasta 48 horas antes del evento. Una vez procesada la
+                                solicitud, el reembolso se realizará en un plazo de 7 a 14 días hábiles.
                             </span>
                         </div>
                         <div class="vstack gap-3">
                             <div>
                                 <label for="ticket_code" class="form-label">Código del ticket</label>
-                                <input class="form-control"
-                                    id="ticket_code"
-                                    required=""
-                                    type="text"
+                                <input class="form-control" id="ticket_code" required="" type="text"
                                     name="ticket_code" />
                             </div>
                             <div>
@@ -34,51 +41,50 @@
                                     <option value="evento_cancelado">Evento modificado</option>
                                     <option value="error_compra">Error en la compra</option>
                                 </select>
-                            </div>                            
+                            </div>
                             <div>
                                 <label for="description" class="form-label">Detalles adicionales</label>
-                                <textarea
-                                    class="form-control"
-                                    id="description"
-                                    name="details"
-                                    rows="4"
+                                <textarea class="form-control" id="description" name="details" rows="4"
                                     placeholder="Proporciona más información sobre tu solicitud de reembolso..."></textarea>
                             </div>
                             <div class="form-check mb-3">
                                 <input class="form-check-input" type="checkbox" id="refundPolicy" required>
                                 <label class="form-check-label" for="refundPolicy">
-                                    Entiendo y acepto la <a href="#" data-bs-toggle="modal" data-bs-target="#refundPolicyModal" style="color: #0d6efd;">política de reembolsos</a>.
+                                    Entiendo y acepto la <a href="#" data-bs-toggle="modal"
+                                        data-bs-target="#refundPolicyModal" style="color: #0d6efd;">política de
+                                        reembolsos</a>.
                                 </label>
                             </div>
                             <div class="text-end">
                                 <button type="submit" class="btn btn-primary">Enviar solicitud</button>
                             </div>
-                       </div>
+                        </div>
                     </form>
                 </div>
             </div>
         </div>
     </div>
 </div>
-<div class="modal fade" id="refundPolicyModal" tabindex="-1" aria-labelledby="refundPolicyModalLabel" aria-hidden="true">
+<div class="modal fade" id="refundPolicyModal" tabindex="-1" aria-labelledby="refundPolicyModalLabel"
+    aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="refundPolicyModalLabel">Política de reembolsos</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="refundPolicyModalLabel">Política de reembolsos</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <ul>
+                    <li>Reembolso del 100% hasta 7 días antes del evento.</li>
+                    <li>Reembolso del 50% entre 2 y 7 días antes del evento.</li>
+                    <li>Sin reembolso a menos de 48 horas del evento.</li>
+                    <li>El reembolso se realiza al mismo método de pago usado en la compra.</li>
+                </ul>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+            </div>
         </div>
-        <div class="modal-body">
-          <ul>
-            <li>Reembolso del 100% hasta 7 días antes del evento.</li>
-            <li>Reembolso del 50% entre 2 y 7 días antes del evento.</li>
-            <li>Sin reembolso a menos de 48 horas del evento.</li>
-            <li>El reembolso se realiza al mismo método de pago usado en la compra.</li>
-          </ul>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-        </div>
-      </div>
     </div>
 </div>
 {% endblock %}

--- a/app/test/test_e2e/base.py
+++ b/app/test/test_e2e/base.py
@@ -74,6 +74,13 @@ class BaseE2ETest(StaticLiveServerTestCase):
         status=Event.Status.ACTIVO
     )
 
+    def create_refund_request(self,ticket,user):
+        return RefundRequest.objects.create(
+            ticket_code=str(ticket.ticket_code),  
+            reason='no_asistencia',
+            requester=user
+        )
+
     
     def login_user(self, username, password):
         """Método auxiliar para iniciar sesión"""

--- a/app/test/test_e2e/test_ticket.py
+++ b/app/test/test_e2e/test_ticket.py
@@ -2,6 +2,7 @@ import re
 import time
 from playwright.sync_api import expect
 from app.test.test_e2e.base import BaseE2ETest
+from app.models import *
 
 class TicketModelTest(BaseE2ETest):
     """Tests relacionados con la compra de tickets"""
@@ -107,3 +108,65 @@ class TicketModelTest(BaseE2ETest):
 
         assert 'text' in alert_message, "No se disparó ningún alert"
         assert "capacidad" in alert_message['text'].lower()
+
+
+    def test_ticket_reembolso_unico(self):
+        # Creo los datos iniciales
+        timestamp = str(int(time.time()))
+        
+        organizer = self.create_test_user(
+            is_organizer=True,
+            username=f"org_{timestamp}"
+        )
+        venue = self.create_test_venue(10) 
+        event = self.create_test_event(organizer, venue)
+        
+
+        user = self.create_test_user(
+            is_organizer=False,
+            username=f"usr_{timestamp}",
+            password="contra129*",
+            email=f"email_{timestamp}@gmail.com"
+        )
+
+        # Inicio sesion
+        self.login_user(username=user.username, password="contra129*")
+
+        # Creo un ticket y un reembolso
+        ticket = self.create_test_ticket(user=user,event=event,quantity=1)
+        refundRequest = self.create_refund_request(ticket,user)
+
+        # Verifico que el test haya creado correctamente el reembolso (el test del test valga la redundancia)
+        reembolsos = RefundRequest.objects.filter(requester=user)
+        print(f"reembolsos: {reembolsos}")        
+        self.assertEqual(reembolsos.count(), 1)
+
+        # El usuario va a hacer un reembolso teniendo uno ya activo
+        self.page.goto(f"{self.live_server_url}/refund/request/")
+
+        # Rellenar el formulario
+        self.page.fill("#ticket_code", str(ticket.ticket_code))
+        self.page.select_option("#refund_reason", value="error_compra")
+        self.page.fill("#description", "Compre el ticket por error")
+        self.page.check("#refundPolicy")
+
+        # Manejar alerta
+        alert_message = {}
+        def handle_dialog(dialog):
+            alert_message['text'] = dialog.message
+            dialog.dismiss()
+        self.page.on("dialog", handle_dialog)
+
+        # El usuario presiona el boton de enviar 
+        self.page.get_by_role("button", name="Enviar solicitud").click()
+        self.page.wait_for_timeout(1000)
+        
+        # Debe saltar un alert que indica que ya hay una solicitud de reembolso pendiente
+        print(f"MENSAJE: {alert_message}")
+        assert 'text' in alert_message, "Ya hay una solicitud de reembolso pendiente."
+
+        # Verifico que no se haya generado una nueva solicitud de reembolso
+        reembolsos = RefundRequest.objects.filter(requester=user)
+        print(f"reembolsos: {reembolsos}")        
+        self.assertEqual(reembolsos.count(), 1)
+        

--- a/app/test/test_integration/test_ticket.py
+++ b/app/test/test_integration/test_ticket.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.contrib.messages import get_messages
 from django.utils import timezone
 from app.models import *
 import datetime
@@ -159,3 +160,87 @@ class TicketModelTest(TestCase):
 
         # Verificamos la lógica
         self.assertTrue(capacidad_utilizada + nueva_cantidad > capacidad_maxima)
+
+class TicketReembolsoTest(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="usuario_test",
+            email="usuario@example.com",
+            password="password123",
+            is_organizer=False,
+        )
+
+        self.userOrganizer = User.objects.create_user(
+            username="organizador_test",
+            email="organizador@example.com",
+            password="password123",
+            is_organizer=True,
+        )
+            
+        self.venue = Venue.objects.create(
+            name="Estadio Central",
+            address="Av. Siempre Viva 123",
+            city="Springfield",
+            capacity=100,
+            contact="contacto@estadiocentral.com"
+        )
+
+        self.category = Category.objects.create(
+            name="Música",
+            description="Eventos relacionados con conciertos y festivales.",
+            is_active=True
+        )
+
+        self.event = Event.objects.create(
+            title="Festival de Jazz",
+            description="Un evento musical imperdible.",
+            scheduled_at=timezone.now() + timezone.timedelta(days=30),
+            organizer=self.userOrganizer,
+            venue=self.venue,
+            status=Event.Status.ACTIVO
+        )
+
+        self.ticket = Ticket.objects.create(
+            quantity=2,
+            type=Ticket.Type.VIP,
+            event=self.event,
+            buy_date=timezone.now(),
+            user=self.user
+        )
+
+        self.RefundRequest = RefundRequest.objects.create(
+            ticket_code=str(self.ticket.ticket_code),  
+            reason='no_asistencia',
+            requester=self.user
+        )
+
+        return super().setUp()
+    
+    def test_ticket_reembolso_unico(self):
+
+        # Iniciar sesion (el usuario ya tenia un reembolso activo de entrada)
+        self.client.login(username="usuario_test", password="password123")
+
+        url = reverse("solicitar_reembolso")
+
+        data = {
+            "ticket_code": str(self.ticket.ticket_code),
+            "reason": "no_asistencia",
+            "details": "no puedo asistir al evento. porfavor reembolsenme!"
+        }
+
+        # Hacemos la solicitud al servidor
+        response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.status_code, 200) 
+
+        # Verificar que no se creó la nueva solicitud de rembolso
+        reembolsos = RefundRequest.objects.filter(requester=self.user)        
+        self.assertEqual(reembolsos.count(), 1)
+
+        # Verificar que el mensaje de error fue agregado
+        messages = list(get_messages(response.wsgi_request))
+        print(messages)
+        self.assertTrue(any("Ya hay una solicitud de reembolso pendiente." in str(m) for m in messages))
+
+        # Verificar que se redirige al formulario
+        self.assertTemplateUsed(response, "request_form.html")

--- a/app/views.py
+++ b/app/views.py
@@ -410,8 +410,25 @@ def view_comment(request, comment_id):
     return render(request, 'comments/view_comment.html', {'comment': comment})
 
 
+def posee_solicitud_reembolso_activa(user) -> bool:
+    '''
+    - Recibe como parametro un usuario
+    - Devuelve True si el usuario posee una solicitud de reembolso que esta activa, es decir, no fue aceptada ni rechazada.
+    - De lo contrario, devuelve False
+    '''
+    refunds = RefundRequest.objects.filter(
+            status=RefundRequest.Status.PENDING,
+            requester=user
+        )
+    if refunds.exists():
+        return True
+    else:
+        return False
+
+
 @login_required
 def solicitar_reembolso(request):
+    
     if request.method == "POST":
         ticket_code = request.POST.get("ticket_code")
         reason = request.POST.get("reason")     
@@ -426,6 +443,11 @@ def solicitar_reembolso(request):
             }
             return render(request, "request_form.html", context)
 
+        # Verificar que el usuario no tenga una solicitud de reembolso activa
+        if(posee_solicitud_reembolso_activa(request.user)):
+            messages.error(request, "Ya hay una solicitud de reembolso pendiente.")
+            return render(request, "request_form.html")
+
         refund_request = RefundRequest.objects.create(
             ticket_code=ticket_code,
             reason=reason,
@@ -436,7 +458,7 @@ def solicitar_reembolso(request):
 
         return redirect("events")
 
-
+    
     return render(request, "request_form.html")
 
 @login_required


### PR DESCRIPTION
Realizacion de la actividad extra solicitada en la 🔗 [Discusión en el repositorio oficial](https://github.com/orgs/frlp-utn-ingsoft/discussions/322). (Vidmar)

Consigna elegida:
 _"12. ​Validar que el usuario no pueda ingresar una solicitud de reembolso si ya
tiene otra activa."_

Se agregó una validación para impedir que un usuario cree una nueva solicitud de reembolso si ya tiene otra en estado pendiente, ademas, se lo notifica al usuario mediante un alert. Esta lógica asegura que cada usuario solo pueda tener una solicitud pendiente a la vez.

Se implementaron los siguientes tests:
- Test unitario
- Test de integración
- Test end-to-end (E2E)