### PR TITLE
Arreglo en la ejecucion del cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,6 @@
 name: Deploy continuo
 
 on:
-  release:
-    types: [published]
   workflow_run:
     workflows: ["Integracion continua"]
     types: [completed]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ["main", "develop"]
   pull_request:
+  release:
+    types: [published]
 
 jobs: 
   build:


### PR DESCRIPTION
Se arregló el error que hacia que el cd se ejecutara sin depender del ci al hacer una release, ahora espera a que termine el ci para ejecutar